### PR TITLE
Update skillwatch.lua

### DIFF
--- a/skillwatch/skillwatch.lua
+++ b/skillwatch/skillwatch.lua
@@ -329,7 +329,7 @@ ashita.events.register('d3d_present', 'present_cb', function()
 	
 	
 	
-    imgui.End();
+    
 	
 	--OVERLAY RENDERING
 	imgui.SetNextWindowSize({ overlay.settings.barWidth, -1, }, ImGuiCond_Always);
@@ -405,6 +405,8 @@ ashita.events.register('d3d_present', 'present_cb', function()
 		imgui.End();
 		--local barColor = imgui.GetColorU32({1,1,1,1});
 		--imgui.GetWindowDrawList():AddRectFilled(imgui.GetCursorScreenPos(), imgui.ImVec2(200,200), barColor, false, ImDrawCornerFlags_None);
+	else
+		imgui.End();
 	end
 	
 end);
@@ -561,6 +563,7 @@ function getAbilities()
 		end);
 		overlay.enabledAbilities = enabledList;
 	end
+
 
 
 end

--- a/skillwatch/skillwatch.lua
+++ b/skillwatch/skillwatch.lua
@@ -325,6 +325,7 @@ ashita.events.register('d3d_present', 'present_cb', function()
 		end
 		
         imgui.EndTabBar();
+		imgui.End();
     end
 	
 	
@@ -400,14 +401,10 @@ ashita.events.register('d3d_present', 'present_cb', function()
 			end
 		end
 		
-		
-		
-		imgui.End();
 		--local barColor = imgui.GetColorU32({1,1,1,1});
 		--imgui.GetWindowDrawList():AddRectFilled(imgui.GetCursorScreenPos(), imgui.ImVec2(200,200), barColor, false, ImDrawCornerFlags_None);
-	else
-		imgui.End();
 	end
+	imgui.End();
 	
 end);
 
@@ -567,3 +564,4 @@ function getAbilities()
 
 
 end
+


### PR DESCRIPTION
Fix double Imgui End issue that causes error in Ashita v4.30

When testing in v4.30 this error happened:
<img width="533" height="101" alt="image" src="https://github.com/user-attachments/assets/1984b3b0-c962-481a-ae9c-36f5caaa059a" />
